### PR TITLE
bug fix, Logic.java updateAttributes

### DIFF
--- a/src/main/java/org/o3project/odenos/core/component/Logic.java
+++ b/src/main/java/org/o3project/odenos/core/component/Logic.java
@@ -1315,7 +1315,7 @@ public abstract class Logic extends Component {
       boolean updated = false;
       Map<String, String> currAttributes = curr.getAttributes();
       for (String key : currAttributes.keySet()) {
-        String oldAttr = body.getAttribute(key);
+        String oldAttr = prev.getAttribute(key);
         if (nodeMessageIgnoreAttributes.contains(key)
             || (oldAttr != null && oldAttr.equals(currAttributes
                 .get(key)))) {
@@ -1372,7 +1372,7 @@ public abstract class Logic extends Component {
       boolean updated = false;
       Map<String, String> currAttributes = curr.getAttributes();
       for (String key : currAttributes.keySet()) {
-        String oldAttr = body.getAttribute(key);
+        String oldAttr = prev.getAttribute(key);
         if (portMessageIgnoreAttributes.contains(key)
             || (oldAttr != null && oldAttr.equals(currAttributes
                 .get(key)))) {
@@ -1428,7 +1428,7 @@ public abstract class Logic extends Component {
       boolean updated = false;
       Map<String, String> currAttributes = curr.getAttributes();
       for (String key : currAttributes.keySet()) {
-        String oldAttr = body.getAttribute(key);
+        String oldAttr = prev.getAttribute(key);
         if (messageIgnoreAttributes.contains(key)
             || (oldAttr != null && oldAttr.equals(currAttributes
                 .get(key)))) {
@@ -1506,7 +1506,7 @@ public abstract class Logic extends Component {
       // attributes copy (curr -> body)
       Map<String, String> currAttributes = curr.getAttributes();
       for (String key : currAttributes.keySet()) {
-        String oldAttr = body.getAttribute(key);
+        String oldAttr = prev.getAttribute(key);
         if (messageIgnoreAttributes.contains(key)
             || (oldAttr != null && oldAttr.equals(currAttributes
                 .get(key)))) {


### PR DESCRIPTION
bug fix, Logic.java

When updating the attribute at Update, and updating the difference between the update target object.
However, if the sequence is congested, there is a case that overwrite the update destination object in the object information of old events.
By comparing the update source of prev and curr As a countermeasure, you want to change to a key only updated there is a difference.

[Japanese]
Updateにてattributeを更新する際に、更新先のオブジェクトとの差分を更新している。
しかしながら、シーケンスが輻輳した場合に、更新先のオブジェクトを古いイベントのオブジェクト情報で上書きしてしまうケースがある。
対策として更新元のprevとcurrを比較して、差分があるkeyのみ更新対象とするように変更する。
