### PR TITLE
Fix for NPE error on EventSubscriptionObjectTest

### DIFF
--- a/src/main/java/org/o3project/odenos/remoteobject/manager/EventSubscriptionObject.java
+++ b/src/main/java/org/o3project/odenos/remoteobject/manager/EventSubscriptionObject.java
@@ -75,6 +75,10 @@ public class EventSubscriptionObject {
             if (event.equals("ComponentConnectionChanged")) {
               continue;
             }
+            // workaround for NPE
+            if (subscriptionMap.get(publisherId) == null) {
+                continue;
+            }
             List<EventSubscription> eventSubs =
                 subscriptionMap.get(publisherId).get(event);
             if (eventSubs != null) {


### PR DESCRIPTION
My understanding of `#setSubscription` is that it removes old subscriptions and then sets the new one specified.

This patch checks if specified publisherId exists during the old subscription removal phase and skips if the publisherId does not exist.
