### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,14 @@ language: java
 jdk:
   - oraclejdk7
   - openjdk7
+  - oraclejdk8
 
 branches:
   only:
     - develop
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install redis-server
   - sudo service redis-server restart
-  - mvn install -DskipTests=true
 
 script:
-  - mvn test
+  - mvn test javadoc:javadoc -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ jdk:
   - openjdk7
   - oraclejdk8
 
-branches:
-  only:
-    - develop
-
 before_install:
   - sudo service redis-server restart
 


### PR DESCRIPTION
- Removed redis installation step.
  - Redis is pre-installed:
    - http://docs.travis-ci.com/user/ci-environment/#Data-Stores
- Run javadoc:javadoc to detect Javadoc tag errors
- Run on JDK8
- mvn install should be invoked on :install phase
  - default :install phase executes mvn install
    - http://docs.travis-ci.com/user/languages/java/#Dependency-Management
