### PR TITLE
Of driver topology

### DIFF
--- a/doc/api/DataClass.md
+++ b/doc/api/DataClass.md
@@ -416,7 +416,7 @@ matches      | list[[OFPFlowMatch](#OFPFlowMatch)] | One or more of the match co
 idle_timeout | \<number>    | Units sec. Is regarded as 0 specified if it is omitted. | Optional  |  Optional  
 hard_timeout | \<number>    | Units sec. Is regarded as 0 specified if it is omitted. | Optional  |  Optional  
 path         | list[[Link](#Link).link_id ] | list of [Link](#Link) that [Flow](#Flow) goes through. there is a need for a connected acyclic graph. | Mandatory |  Mandatory
-edge_actions | dict<[Node](#Node).node_id, list[[BasicFlowAction](#BasicFlowAction)]> |Action of edge node.  | Mandatory |  Mandatory
+edge_actions | dict<[Node](#Node).node_id, list[[OFPFlowAction](#OFPFlowAction)]> |Action of edge node.  | Mandatory |  Mandatory
 
 
 ----

--- a/src/main/ruby/org/o3project/odenos/component/driver/of_driver/ruby_topology/topology.rb
+++ b/src/main/ruby/org/o3project/odenos/component/driver/of_driver/ruby_topology/topology.rb
@@ -112,7 +112,13 @@ module Odenos
                 fail 'Not an LLDP packet!'
               end
 
-              link = Link.new(dpid, packet_in)
+              begin
+                link = Link.new(dpid, packet_in)
+              rescue => e
+                lldp = Pio::Lldp.read(packet_in.data.pack('C*'))
+                warn ">>Can not be created link dpid:#{dpid} lldp.lpid:#{lldp.dpid}"
+              end
+
               unless @links.include?(link)
                 @links << link
                 @links.sort!


### PR DESCRIPTION
In case of connecting the OFS with different controllers is not performed LINK processing.

異なるコントローラでOFSを接続するケースにおいて、異なるコントローラからのLLDP通知の場合にLINK処理を行わない。
