### PR TITLE
Update Link attribute `oper_status` description

### DIFF
--- a/doc/api/DataClass.md
+++ b/doc/api/DataClass.md
@@ -76,7 +76,7 @@ oper_status  | \<String> | "UP" : Physical device normal. <br> "DOWN" : Physical
 physical_id  | \<String> |ID of the physical device. Numbering in the driver.<br> For example, openflow driver to set the "dpid" | any         |   Lower  ->  Upper
 vendor        | \<String>  |Vendor name is set.<br> For example, It is used for the GUI system. | any | Lower -> Upper
 
-(*) **Lower** : Driver side. **Upper** : Controller side.
+(\*) **Lower** : Driver side. **Upper** : Controller side.
 
 
 ----
@@ -109,7 +109,7 @@ physical_id   | \<String>  |ID of the physical device. Driver may assign this ID
 vendor        | \<String>  |Vendor name is set.<br> For example, It is used for the GUI system. | any | Lower -> Upper
 is_boundary   | "true" or "false" |[Boundary](#Boundary) setting is the "true" when enabled. <br> For example, It is used for the GUI system. | "false" |  Upper -> Lower 
 
-(*) **Lower** : Driver side. **Upper** : Controller side.
+(\*) **Lower** : Driver side. **Upper** : Controller side.
 
 
 ----
@@ -133,7 +133,7 @@ attributes|dict{\<String>, \<String>}|See the table attributes.   | Optional  | 
 ##### Attributes
 **Key**              | **Value** |**Description**                                                                      | init  | Direction of the reflected(*)
 ---------------------|-----------|-------------------------------------------------------------------------------------|-------|-----------------
-oper_status          | \<String> | "UP" : Physical device normal. <br> "DOWN" : Physical device failure.               | any   | Lower -> Upper
+oper_status          | \<String> | "UP" : Link is in a state ready to forward traffic. <br> "DOWN" : Link is in a state not ready to forward traffic.               | any   | Lower -> Upper
 cost                 | \<Number> | link cost.                                                                          | 1     | Upper -> Lower              
 req_latency          | \<Number> | Unit is msec. Request latency. (There may be different from the actual latency.）   | any   | Upper -> Lower
 latency              | \<Number> | Unit is  msec.                                                                      | any   | Lower -> Upper                 
@@ -142,7 +142,7 @@ max_bandwidth        | \<Number> | Unit is Mbps. maximum bandwidth of the port.<
 unreserved_bandwidth | \<Number> | Unit is Mbps. Current bandwidth of the port.<br > Driver to set the initial value.  |max_bandwidth   | Upper -> Lower 
 establishment_status | \<string> |Use LinkLayerizer Only. Link that was generated from Flow. <br> "establishing" :  <br>   "established" :  <br> If it is a "establishing", oper_status is "DOWN" | any    | -
 
-(*) **Lower** : Driver side. **Upper** : Controller side.
+(\*) **Lower** : Driver side. **Upper** : Controller side.
 
 
 ----


### PR DESCRIPTION
- MarkDown formatting fix
