### PR TITLE
Verify in/out Link does not disappear after PUT.

### DIFF
--- a/doc/api/Network.md
+++ b/doc/api/Network.md
@@ -289,7 +289,7 @@ can not delete if the link is set to port.
 
 ---- 
 ### <a name="POSTports">POST \<base_uri>/topology/nodes/\<node_id>/ports</a>  
-add a Port to Node.id is granted automatically. (specified id is invalid)
+add a Port to Node. Port id will be generated automatically. (Port id specified by request body will be ignored)
 
 
 ##### [Request]:   
@@ -324,7 +324,7 @@ get the port.  (specify the id that you want to get)
 
 ----
 #### <a name="PUTport_id">PUT \<base_uri>/topology/nodes/\<node_id>/ports/\<port_id></a>  
-update the port.(specify the id that you want to update)  
+update the port.  (specify the id that you want to update)  
 create a new port if id does not exist.
 
 

--- a/src/test/java/org/o3project/odenos/core/component/network/NetworkTest.java
+++ b/src/test/java/org/o3project/odenos/core/component/network/NetworkTest.java
@@ -1219,12 +1219,21 @@ public class NetworkTest {
      * test
      */
     Port port = new Port("1", "NodeId", "PortId");
+    port.setInLink("LinkIn");
+    port.setOutLink("LinkOut");
     Response result = target.putPort("NodeId", "PortId", port);
 
     /*
      * check
      */
     assertThat(result.statusCode, is(Response.OK));
+    // In/Out Link is expected to be ignored on PUT Port
+    Port expectedPort = new Port("1", "PortId", "NodeId");
+    expectedPort.setInLink(null);
+    expectedPort.setOutLink(null);
+    expectedPort.updateVersion();
+    assertThat(result.getBody(Port.class), is(expectedPort));
+
   }
 
   /**


### PR DESCRIPTION
When you PUT a Port with In/Out LinkId specified, Network component ignores the specified In/Out LinkId.  Is this intended behavior?
