### PR TITLE
Odenos.py Redis host/port config

### DIFF
--- a/odenos
+++ b/odenos
@@ -37,7 +37,7 @@ ODENOS_TMP=/tmp
 REST_PORT=10080
 REST_ROOT=.
 
-ODENOS_OPT="-Xms512m -Xmx512m -server"
+ODENOS_OPT="-Xms2048m -Xmx2048m -server"
 ODENOS_MAIN=org.o3project.odenos.core.Odenos
 FILE_ODENOS_SYSTEM_PID=$ODENOS_TMP/odenos_system.pid
 
@@ -183,7 +183,7 @@ start_process() {
 		LOGGING_CONF=${ODENOS_CONF}/log_python.conf \
 		APP_LOG=${ODENOS_LOG}/odenos_${PROC_NAME}.log \
 		$PYTHON ${ODENOS_LIB}/python/org/o3project/odenos/core/odenos.py \
-		-r ${PROC_NAME} -d ${PROC_DIR} &
+		-r ${PROC_NAME} -d ${PROC_DIR} -i $HOST -p $PORT &
 
 	    echo $! > $ODENOS_TMP/odenos_${PROC_NAME}.pid
 

--- a/odenos
+++ b/odenos
@@ -37,7 +37,7 @@ ODENOS_TMP=/tmp
 REST_PORT=10080
 REST_ROOT=.
 
-ODENOS_OPT="-Xms2048m -Xmx2048m -server"
+ODENOS_OPT="-Xms512m -Xmx512m -server"
 ODENOS_MAIN=org.o3project.odenos.core.Odenos
 FILE_ODENOS_SYSTEM_PID=$ODENOS_TMP/odenos_system.pid
 

--- a/src/main/python/org/o3project/odenos/core/odenos.py
+++ b/src/main/python/org/o3project/odenos/core/odenos.py
@@ -39,6 +39,8 @@ class Parser(object):
         parser = OptionParser()
         parser.add_option("-r", dest="rid", help="ComponentManager ID")
         parser.add_option("-d", dest="dir", help="Directory of Components")
+        parser.add_option("-i", dest="ip", help="Pubsub server host name or ip address", default="localhost")
+        parser.add_option("-p", dest="port", help="Pubsub server port number", type=int, default=6379)
         (options, args) = parser.parse_args()
         return options
 
@@ -69,7 +71,7 @@ if __name__ == '__main__':
     options = Parser().parse()
     logging.info("python ComponentManager options: %s", options)
 
-    dispatcher = MessageDispatcher()
+    dispatcher = MessageDispatcher(redis_server=options.ip, redis_port=options.port)
     dispatcher.start()
 
     component_manager = ComponentManager(options.rid, dispatcher)


### PR DESCRIPTION
The "odenos" script starts odenos.py with two additional arguements: (-i) Redis servehost and (-p) port that are set in etc/odenos.conf.
