### PR TITLE
Message sequence monitor for Python-based ODENOS implementation (issue #82)

### DIFF
--- a/apps/monitor/README.md
+++ b/apps/monitor/README.md
@@ -1,9 +1,9 @@
-OdenOS message sequence diagram generator
-=========================================
+monitor: ODENOS message sequence diagram generator
+==================================================
 
-The program "monitor" taps Redis server to monitor messages exchanged among OdenOS RemoteObject instances, then automatically generates a message sequence diagram.
+The program "monitor" monitors messages being exchanged among ODENOS RemoteObject instances, then automatically generates a message sequence diagram.
 
-Everything works in an asynchronous manner with coroutines supported by Tornado packege.
+Everything works in an asynchronous manner with Python coroutines (Python generators) supported by Tornado package.
 
 Screen shots
 ------------
@@ -24,14 +24,15 @@ $ sudo pip3 install tornado-redis
 
 Limitation
 ----------
-Python/Ruby-based message_dispatcher does now work with this tool at the moment.
+- Browsers other than Firefox may not work with this tool.
+- Ruby-based message_dispatcher does now work with this tool at the moment.
 
 
 Architecture
 ------------
 ```
 +------------------------------++++
-| OdenOS RemoteObject instance |||| resttranslator, systemmanager, ...
+| ODENOS RemoteObject instance |||| resttranslator, systemmanager, ...
 +------------------------------++++
          | |  |  |
   publish/subscribe/message
@@ -41,23 +42,25 @@ Architecture
        | server    |
        +-----------+
           ^      |
-subscribe'_monitor'
+subscribe '_monitor'
           |      |
           |  message (non-blocking IO: tornado-redis)
           |      |
           |      V
-       +-----------+
-       | monitor   | Tornado web server (coroutine-based)
-       |           |
-       +-----------+
-          |     ^
-     WebSocket  |
-          |    GET message detail
-          V     |
-       +-----------+
-       | browser   | index.html (HTML5 + CSS + JavaScript)
-       |           |
-       +-----------+
+       +-------------------+
+       | monitor           | Tornado web server (coroutine-based)
+       |                   |
+       +-------------------+
+          |     ^     |
+     WebSocket  |     |
+          |    GET   200 OK
+          |  message  |
+          |  detail  message detail
+          V     |     V
+       +-------------------+
+       | browser           | index.html (HTML5 + CSS + JavaScript)
+       |                   |
+       +-------------------+
 ```
 
 
@@ -73,7 +76,7 @@ $ monitor -h
 Start monitoring:
 $ monitor resttranslator systemmanager romgr1 network1 ...
 
-Start monitoring with "default.yaml":
+Start monitoring messages being exchanged among ODENOS RemoteObject instances pre-defined in "default.yaml":
 $ monitor
 
 Start monitoring with additional parameters:

--- a/apps/monitor/monitor
+++ b/apps/monitor/monitor
@@ -318,6 +318,8 @@ class Monitor:
                 arrow.append('')
             self.output(final_format.format(*arrow))
             if self.detail_output:
+                self.output('dstid: {}'.format(dstid))
+                self.output('srcid: {}'.format(srcid))
                 if self.json_format:
                     self.output(json.dumps(decode(self.message_buffer[serial])))
                 else:

--- a/odenos
+++ b/odenos
@@ -183,7 +183,7 @@ start_process() {
 		LOGGING_CONF=${ODENOS_CONF}/log_python.conf \
 		APP_LOG=${ODENOS_LOG}/odenos_${PROC_NAME}.log \
 		$PYTHON ${ODENOS_LIB}/python/org/o3project/odenos/core/odenos.py \
-		-r ${PROC_NAME} -d ${PROC_DIR} -i $HOST -p $PORT &
+		-r ${PROC_NAME} -d ${PROC_DIR} -S $MANAGER -i $HOST -p $PORT -m $MONITOR &
 
 	    echo $! > $ODENOS_TMP/odenos_${PROC_NAME}.pid
 

--- a/src/main/java/org/o3project/odenos/remoteobject/messagingclient/MessageDispatcher.java
+++ b/src/main/java/org/o3project/odenos/remoteobject/messagingclient/MessageDispatcher.java
@@ -280,7 +280,7 @@ public class MessageDispatcher implements Closeable, IMessageListener {
             pk.write("/" + channel + "/" + request.path);
             pk.write(request.getBodyValue());
             byte[] data = pk.toByteArray();
-            driverImpl.publish(MONITOR_CHANNEL, data);
+            monitor.publish(MONITOR_CHANNEL, data);
           }
 
           // Wraps the request with Mail and deliver it to a mailbox.

--- a/src/main/python/org/o3project/odenos/core/component/logic.py
+++ b/src/main/python/org/o3project/odenos/core/component/logic.py
@@ -71,7 +71,7 @@ class Logic(Component):
         # SystemManager IF
         if self.dispatcher is None:
             return
-        self._sys_manager_interface = SystemManagerInterface(dispatcher)
+        self._sys_manager_interface = SystemManagerInterface(dispatcher, object_id)
 
     ###################################
     # Receive ComponentConnectionChanged
@@ -93,7 +93,7 @@ class Logic(Component):
                 if network_id in self._network_interfaces:
                     return
                 self._network_interfaces[network_id] = \
-                    NetworkInterface(self.dispatcher, network_id)
+                    NetworkInterface(self.dispatcher, network_id, self.object_id())
                 self._connection_changed_added(msg)
         elif msg.action == ComponentConnectionChanged.Action.UPDATE:
             if (self._connection_changed_update_pre(msg)):

--- a/src/main/python/org/o3project/odenos/core/component/logic.py
+++ b/src/main/python/org/o3project/odenos/core/component/logic.py
@@ -93,7 +93,7 @@ class Logic(Component):
                 if network_id in self._network_interfaces:
                     return
                 self._network_interfaces[network_id] = \
-                    NetworkInterface(self.dispatcher, network_id, self.object_id())
+                    NetworkInterface(self.dispatcher, network_id, self.object_id)
                 self._connection_changed_added(msg)
         elif msg.action == ComponentConnectionChanged.Action.UPDATE:
             if (self._connection_changed_update_pre(msg)):

--- a/src/main/python/org/o3project/odenos/core/odenos.py
+++ b/src/main/python/org/o3project/odenos/core/odenos.py
@@ -41,6 +41,8 @@ class Parser(object):
         parser.add_option("-d", dest="dir", help="Directory of Components")
         parser.add_option("-i", dest="ip", help="Pubsub server host name or ip address", default="localhost")
         parser.add_option("-p", dest="port", help="Pubsub server port number", type=int, default=6379)
+        parser.add_option("-m", dest="monitor", help="Toggle monitor", default="false")
+        parser.add_option("-S", dest="manager", help="System Manager ID", default="systemmanager")
         (options, args) = parser.parse_args()
         return options
 
@@ -71,7 +73,10 @@ if __name__ == '__main__':
     options = Parser().parse()
     logging.info("python ComponentManager options: %s", options)
 
-    dispatcher = MessageDispatcher(redis_server=options.ip, redis_port=options.port)
+    dispatcher = MessageDispatcher(system_manager_id=options.manager,
+                                   redis_server=options.ip,
+                                   redis_port=options.port,
+                                   enable_monitor=(options.monitor=="true"))
     dispatcher.start()
 
     component_manager = ComponentManager(options.rid, dispatcher)
@@ -92,7 +97,7 @@ if __name__ == '__main__':
 
     classes.append(DummyDriver)
     component_manager.register_components(classes)
-    sysmgr = SystemManagerInterface(dispatcher)
+    sysmgr = SystemManagerInterface(dispatcher, options.rid)
     sysmgr.add_component_manager(component_manager)
     component_manager.set_state(ObjectProperty.State.RUNNING)
 

--- a/src/main/python/org/o3project/odenos/core/util/network_interface.py
+++ b/src/main/python/org/o3project/odenos/core/util/network_interface.py
@@ -75,9 +75,9 @@ class NetworkInterface(RemoteObjectInterface):
     OUTPACKETS_HEAD_PATH = "packets/out/head"
     PACKETS_PATH = "packets"
 
-    def __init__(self, dispatcher, network_id):
+    def __init__(self, dispatcher, network_id, source_object_id=None):
         logging.debug("Create NetworkInterface : NetworkID:" + network_id)
-        super(NetworkInterface, self).__init__(dispatcher, network_id)
+        super(NetworkInterface, self).__init__(dispatcher, network_id, source_object_id)
 
     @property
     def network_id(self):

--- a/src/main/python/org/o3project/odenos/core/util/network_interface.py
+++ b/src/main/python/org/o3project/odenos/core/util/network_interface.py
@@ -76,6 +76,9 @@ class NetworkInterface(RemoteObjectInterface):
     PACKETS_PATH = "packets"
 
     def __init__(self, dispatcher, network_id, source_object_id=None):
+        '''
+        NOTE: source_object_id is required for the ODENOS monitor tool.
+        '''
         logging.debug("Create NetworkInterface : NetworkID:" + network_id)
         super(NetworkInterface, self).__init__(dispatcher, network_id, source_object_id)
 

--- a/src/main/python/org/o3project/odenos/core/util/remote_object_interface.py
+++ b/src/main/python/org/o3project/odenos/core/util/remote_object_interface.py
@@ -27,6 +27,9 @@ class RemoteObjectInterface(object):
     SETTINGS_PATH = "settings"
 
     def __init__(self, dispatcher, object_id, source_object_id=None):
+        '''
+        NOTE: source_object_id is required for the ODENOS monitor tool.
+        '''
         self.__dispatcher = dispatcher
         self.__object_id = object_id
         self.__source_object_id = source_object_id
@@ -37,6 +40,9 @@ class RemoteObjectInterface(object):
     
     @property
     def source_object_id(self):
+        '''
+        ID of ODENOS RemoteObject instance using this interface.
+        '''
         return self.__source_object_id
 
     ###################################
@@ -113,7 +119,7 @@ class RemoteObjectInterface(object):
                         None)
         req = Request(self.__object_id, method, path, body=body)
         try:
-            resp = self.__dispatcher.request_sync(req, self.__source_object_id)
+            resp = self.__dispatcher.request_sync(req, self.source_object_id)
         except:
             logging.error("Exception: Request to " + self.__object_id
                           + " Method:" + method

--- a/src/main/python/org/o3project/odenos/core/util/remote_object_interface.py
+++ b/src/main/python/org/o3project/odenos/core/util/remote_object_interface.py
@@ -26,13 +26,18 @@ class RemoteObjectInterface(object):
     PROPETY_PATH = "property"
     SETTINGS_PATH = "settings"
 
-    def __init__(self, dispatcher, object_id):
+    def __init__(self, dispatcher, object_id, source_object_id=None):
         self.__dispatcher = dispatcher
         self.__object_id = object_id
+        self.__source_object_id = source_object_id
 
     @property
     def object_id(self):
         return self.__object_id
+    
+    @property
+    def source_object_id(self):
+        return self.__source_object_id
 
     ###################################
     # Basic request
@@ -72,8 +77,7 @@ class RemoteObjectInterface(object):
     ###################################
 
     def _post_object_to_remote_object(self, path, body):
-        resp = self.__send_request(self.__object_id, Request.Method.POST,
-                                   path, body)
+        resp = self.__send_request(Request.Method.POST, path, body)
         if resp.is_error(Request.Method.POST):
             logging.debug("Error Response POST DestID:" + self.__object_id
                           + " Path:" + path
@@ -81,8 +85,7 @@ class RemoteObjectInterface(object):
         return resp
 
     def _put_object_to_remote_object(self, path, body):
-        resp = self.__send_request(self.__object_id, Request.Method.PUT,
-                                   path, body)
+        resp = self.__send_request(Request.Method.PUT, path, body)
         if resp.is_error(Request.Method.PUT):
             logging.debug("Error Response PUT DestID:" + self.__object_id
                           + " Path:" + path
@@ -90,8 +93,7 @@ class RemoteObjectInterface(object):
         return resp
 
     def _del_object_to_remote_object(self, path, body=None):
-        resp = self.__send_request(self.__object_id, Request.Method.DELETE,
-                                   path, body=body)
+        resp = self.__send_request(Request.Method.DELETE, path, body=body)
         if resp.is_error(Request.Method.DELETE):
             logging.debug("Error Response DELETE DestID:" + self.__object_id
                           + " Path:" + path
@@ -99,21 +101,21 @@ class RemoteObjectInterface(object):
         return resp
 
     def _get_object_to_remote_object(self, path):
-        resp = self.__send_request(self.__object_id, Request.Method.GET, path)
+        resp = self.__send_request(Request.Method.GET, path)
         if resp.is_error(Request.Method.GET):
             logging.debug("Error Response GET DestID:" + self.__object_id
                           + " Path:" + path
                           + " StatusCode:" + str(resp.status_code))
         return resp
 
-    def __send_request(self, object_id, method, path, body=None):
+    def __send_request(self, method, path, body=None):
         resp = Response(Response.StatusCode.INTERNAL_SERVER_ERROR,
                         None)
-        req = Request(object_id, method, path, body=body)
+        req = Request(self.__object_id, method, path, body=body)
         try:
-            resp = self.__dispatcher.request_sync(req)
+            resp = self.__dispatcher.request_sync(req, self.__source_object_id)
         except:
-            logging.error("Exception: Request to " + object_id
+            logging.error("Exception: Request to " + self.__object_id
                           + " Method:" + method
                           + " Path:" + path)
             logging.error(traceback.format_exc())

--- a/src/main/python/org/o3project/odenos/core/util/system_manager_interface.py
+++ b/src/main/python/org/o3project/odenos/core/util/system_manager_interface.py
@@ -40,12 +40,12 @@ class SystemManagerInterface(RemoteObjectInterface):
     CONNECTION_PATH = "connections/%s"
     OBJECT_PATH = "objects/%s"
 
-    def __init__(self, dispatcher):
+    def __init__(self, dispatcher, source_object_id=None):
         logging.debug("Create SystemManagerInterface ID:"
                       + dispatcher.system_manager_id)
         super(SystemManagerInterface, self).__init__(
             dispatcher,
-            dispatcher.system_manager_id)
+            dispatcher.system_manager_id, source_object_id)
 
     @property
     def system_manager_id(self):

--- a/src/main/python/org/o3project/odenos/core/util/system_manager_interface.py
+++ b/src/main/python/org/o3project/odenos/core/util/system_manager_interface.py
@@ -41,11 +41,15 @@ class SystemManagerInterface(RemoteObjectInterface):
     OBJECT_PATH = "objects/%s"
 
     def __init__(self, dispatcher, source_object_id=None):
+        '''
+        NOTE: source_object_id is required for the ODENOS monitor tool.
+        '''
         logging.debug("Create SystemManagerInterface ID:"
                       + dispatcher.system_manager_id)
         super(SystemManagerInterface, self).__init__(
             dispatcher,
-            dispatcher.system_manager_id, source_object_id)
+            dispatcher.system_manager_id,
+            source_object_id)
 
     @property
     def system_manager_id(self):

--- a/src/main/python/org/o3project/odenos/remoteobject/remote_object.py
+++ b/src/main/python/org/o3project/odenos/remoteobject/remote_object.py
@@ -98,7 +98,7 @@ class RemoteObject(object):
                                                     method,
                                                     path,
                                                     body),
-                                            self.object_id())
+                                            self.object_id)
 
     def _request(self, object_id, method, path, body=None):
         resp = Response(Response.StatusCode.INTERNAL_SERVER_ERROR, None)

--- a/src/main/python/org/o3project/odenos/remoteobject/remote_object.py
+++ b/src/main/python/org/o3project/odenos/remoteobject/remote_object.py
@@ -97,7 +97,8 @@ class RemoteObject(object):
         return self.dispatcher.request_sync(Request(object_id,
                                                     method,
                                                     path,
-                                                    body))
+                                                    body),
+                                            self.object_id())
 
     def _request(self, object_id, method, path, body=None):
         resp = Response(Response.StatusCode.INTERNAL_SERVER_ERROR, None)

--- a/src/main/python/org/o3project/odenos/remoteobject/transport/message_dispatcher.py
+++ b/src/main/python/org/o3project/odenos/remoteobject/transport/message_dispatcher.py
@@ -309,6 +309,7 @@ class MessageDispatcher:
     def request_sync(self, request, source_object_id=None):
         client = self.__get_message_client(request.object_id)
         logging.debug("[request_sync ]:send to " + client.object_id)
+        logging.debug("[request_sync ]:from " + source_object_id)
         return client.send_request_message(request, source_object_id)
 
     def publish_event_async(self, event):
@@ -333,6 +334,7 @@ class MessageDispatcher:
         resb.extend(pk.pack(self.REQUEST))
         resb.extend(pk.pack(channel))
         resb.extend(pk.pack(source_object_id))
+        resb.extend(pk.pack(sno))
         resb.extend(pk.pack(request.method))
         resb.extend(pk.pack("/" + channel + "/" + request.path))
         resb.extend(pk.pack(request.packed_object()))
@@ -388,7 +390,7 @@ class MessageDispatcher:
                           Request.Method.PUT,
                           "settings/event_subscriptions/%s" % event_subscription.subscriber_id,
                           event_subscription)
-        return self.request_sync(request)
+        return self.request_sync(request, self.get_source_dispatcher_id())
 
     def pushPublishQueue(self, trans, type_, sno, channel, data):
         self.__pubsqueue.put(MessageDispatcher.PublishData(trans,

--- a/src/main/python/org/o3project/odenos/remoteobject/transport/message_dispatcher.py
+++ b/src/main/python/org/o3project/odenos/remoteobject/transport/message_dispatcher.py
@@ -307,9 +307,11 @@ class MessageDispatcher:
             RemoteMessageTransport(self.system_manager_id, self)
 
     def request_sync(self, request, source_object_id=None):
+        '''
+        Note: source_object_id is required for the ODENOS monitor tool.
+        '''
         client = self.__get_message_client(request.object_id)
         logging.debug("[request_sync ]:send to " + client.object_id)
-        logging.debug("[request_sync ]:from " + source_object_id)
         return client.send_request_message(request, source_object_id)
 
     def publish_event_async(self, event):
@@ -328,6 +330,7 @@ class MessageDispatcher:
     def publish_reflected_request(self, channel, source_object_id, sno, request):
         '''
         Publishes an event as a reflected request to the monitor.
+        Note: this function is for the ODENOS monitor tool.
         '''
         pk = msgpack.Packer()
         resb = bytearray()
@@ -347,6 +350,7 @@ class MessageDispatcher:
     def publish_reflected_response(self, channel, source_object_id, sno, response):
         '''
         Publishes an event as a reflected response to the monitor.
+        Note: this function is for the ODENOS monitor tool.
         '''
         pk = msgpack.Packer()
         resb = bytearray()
@@ -365,6 +369,7 @@ class MessageDispatcher:
     def publish_reflected_event(self, channel, subscriber, event):
         '''
         Publishes an event as a reflected event to the monitor.
+        Note: this function is for the ODENOS monitor tool.
         '''
         pk = msgpack.Packer()
         resb = bytearray()

--- a/src/main/python/org/o3project/odenos/remoteobject/transport/message_dispatcher.py
+++ b/src/main/python/org/o3project/odenos/remoteobject/transport/message_dispatcher.py
@@ -45,6 +45,12 @@ class MessageDispatcher:
     SYSTEM_MANAGER_ID = "systemmanager"
     TIME_RETRY_INTERVAL = 100
 
+    # For monitor
+    MONITOR_CHANNEL = "_monitor"
+    REQUEST = "REQUEST"
+    RESPONSE = "RESPONSE"
+    EVENT = "EVENT"
+
     class EventSubscriptionMap:
 
         def __init__(self):
@@ -104,7 +110,8 @@ class MessageDispatcher:
 
     def __init__(self, system_manager_id=SYSTEM_MANAGER_ID,
                  redis_server=REDIS_SERVER,
-                 redis_port=REDIS_PORT):
+                 redis_port=REDIS_PORT,
+                 enable_monitor=False):
         self.__clients = {}
         self.__local_objects = {}
         self.__event_manager_id = None
@@ -116,8 +123,12 @@ class MessageDispatcher:
         self.__redisSubscriberThread = None
         self.__redisSubscriber = None
         self.__redisPublisherThread = None
-        self.__redisPubliser = None
+        self.__redisPublisher = None
         self.__subscription_map = self.EventSubscriptionMap()
+        self.__enable_monitor=enable_monitor
+    
+    def monitor_enabled(self):
+        return self.__enable_monitor
 
     def __redisPublisherRunnable(self):
         while (True):
@@ -125,7 +136,7 @@ class MessageDispatcher:
             if pubs is None:
                 break
             try:
-                self.__redisPubliser.publish(pubs.channel, pubs.data)
+                self.__redisPublisher.publish(pubs.channel, pubs.data)
             except:
                 if pubs.type == self.TYPE_REQUEST:
                     if pubs.trans is not None:
@@ -139,6 +150,7 @@ class MessageDispatcher:
             if mesg['type'] != 'message':
                 continue
             try:
+                channel = mesg['channel']
                 bio = BytesIO()
                 bio.write(mesg['data'])
                 bio.seek(0)
@@ -170,16 +182,27 @@ class MessageDispatcher:
                                             request,
                                             sno,
                                             srcid)
+                    if self.monitor_enabled():  # Monitor
+                        self.publish_reflected_request(channel,
+                                                       srcid,
+                                                       sno,
+                                                       request)
+                                            
                 elif tp == self.TYPE_RESPONSE:
                     trans = self.__clients[srcid]
                     response = Response.create_from_packed(upk.unpack())
                     trans.signalResponse(sno, response)
+                    if self.monitor_enabled():  # Monitor
+                        self.publish_reflected_response(channel,
+                                                        srcid,
+                                                        sno,
+                                                        response)
                 elif tp == self.TYPE_EVENT:
                     event = Event.create_from_packed(upk.unpack())
 
                     def event_runnable(event):
                         try:
-                            self.dispatch_event(event)
+                            self.dispatch_event(channel, event)
                         except:
                             logging.exception('Event processing error')
                     self.thread_pool.submit(event_runnable, event)
@@ -189,7 +212,7 @@ class MessageDispatcher:
 
     def start(self):
         self.thread_pool = futures.ThreadPoolExecutor(max_workers=8)
-        self.__redisPubliser = redis.StrictRedis(host=self.__redisServer,
+        self.__redisPublisher = redis.StrictRedis(host=self.__redisServer,
                                                  port=self.__redisPort)
         self.__redisSubscriber = redis.StrictRedis(
             host=self.__redisServer,
@@ -240,7 +263,7 @@ class MessageDispatcher:
         return self.__sourceDispatcherId
 
     def getRedisPublisher(self):
-        return self.__redisPubliser
+        return self.__redisPublisher
 
     def __update_subscriber(self):
         if self.__redisSubscriber is not None:
@@ -283,10 +306,10 @@ class MessageDispatcher:
         self.__clients[self.system_manager_id] = \
             RemoteMessageTransport(self.system_manager_id, self)
 
-    def request_sync(self, request):
+    def request_sync(self, request, source_object_id=None):
         client = self.__get_message_client(request.object_id)
         logging.debug("[request_sync ]:send to " + client.object_id)
-        return client.send_request_message(request)
+        return client.send_request_message(request, source_object_id)
 
     def publish_event_async(self, event):
         pk = msgpack.Packer()
@@ -299,6 +322,59 @@ class MessageDispatcher:
                               self.TYPE_EVENT,
                               0,
                               event.publisher_id + ":" + event.event_type,
+                              resb)
+
+    def publish_reflected_request(self, channel, source_object_id, sno, request):
+        '''
+        Publishes an event as a reflected request to the monitor.
+        '''
+        pk = msgpack.Packer()
+        resb = bytearray()
+        resb.extend(pk.pack(self.REQUEST))
+        resb.extend(pk.pack(channel))
+        resb.extend(pk.pack(source_object_id))
+        resb.extend(pk.pack(request.method))
+        resb.extend(pk.pack("/" + channel + "/" + request.path))
+        resb.extend(pk.pack(request.packed_object()))
+        self.pushPublishQueue(None,
+                              self.TYPE_REQUEST,
+                              sno,
+                              self.MONITOR_CHANNEL,
+                              resb)
+
+    def publish_reflected_response(self, channel, source_object_id, sno, response):
+        '''
+        Publishes an event as a reflected response to the monitor.
+        '''
+        pk = msgpack.Packer()
+        resb = bytearray()
+        resb.extend(pk.pack(self.RESPONSE))
+        resb.extend(pk.pack(channel))
+        resb.extend(pk.pack(source_object_id))
+        resb.extend(pk.pack(sno))
+        resb.extend(pk.pack(response.status_code))
+        resb.extend(pk.pack(response.packed_object()))
+        self.pushPublishQueue(None,
+                              self.TYPE_RESPONSE,
+                              sno,
+                              self.MONITOR_CHANNEL,
+                              resb)
+
+    def publish_reflected_event(self, channel, subscriber, event):
+        '''
+        Publishes an event as a reflected event to the monitor.
+        '''
+        pk = msgpack.Packer()
+        resb = bytearray()
+        resb.extend(pk.pack(self.EVENT))
+        resb.extend(pk.pack(subscriber))
+        resb.extend(pk.pack(event.publisher_id))
+        resb.extend(pk.pack(channel))
+        resb.extend(pk.pack(event.packed_object()))
+        self.pushPublishQueue(None,
+                              self.TYPE_EVENT,
+                              0,
+                              self.MONITOR_CHANNEL,
                               resb)
 
     def subscribe_event(self, event_subscription):
@@ -328,7 +404,7 @@ class MessageDispatcher:
         else:
             return Response(404, None)
 
-    def dispatch_event(self, event):
+    def dispatch_event(self, channel, event):
         subscribers = self.__subscription_map.get_subscribers(
             event.publisher_id,
             event.event_type)
@@ -339,6 +415,8 @@ class MessageDispatcher:
                     del_obj_ids.append(es)
                     continue
                 self.__local_objects[es].dispatch_event(event)
+                if self.monitor_enabled():  # Monitor
+                    self.publish_reflected_event(channel, es, event)
         for id in del_obj_ids:
             del self.__local_objects[id]
             self.__subscription_map.remove_subscription(id)

--- a/src/main/python/org/o3project/odenos/remoteobject/transport/remote_message_transport.py
+++ b/src/main/python/org/o3project/odenos/remoteobject/transport/remote_message_transport.py
@@ -64,6 +64,9 @@ class RemoteMessageTransport(BaseMessageTransport):
         self.responseMap = {}
 
     def send_request_message(self, request, source_object_id):
+        '''
+        NOTE: source_object_id is required for the ODENOS monitor tool.
+        '''
         logging.debug("[(B1) send request ]: " + str(request.packed_object()))
         queue = self.addRequet(request, source_object_id)
         response = queue.get()
@@ -82,7 +85,7 @@ class RemoteMessageTransport(BaseMessageTransport):
                 message_dispatcher.MessageDispatcher.TYPE_REQUEST))
             reqb.extend(pk.pack(sno))
             if self.dispatcher.monitor_enabled():  # Monitor
-                reqb.extend(pk.pack(source_object_id))
+                reqb.extend(pk.pack(source_object_id))  # Uses source_object_id instead.
             else:
                 reqb.extend(pk.pack(self.dispatcher.get_source_dispatcher_id()))
             reqb.extend(pk.pack(request.packed_object()))

--- a/src/main/python/org/o3project/odenos/remoteobject/transport/remote_message_transport.py
+++ b/src/main/python/org/o3project/odenos/remoteobject/transport/remote_message_transport.py
@@ -63,15 +63,15 @@ class RemoteMessageTransport(BaseMessageTransport):
         self.seqnoGenerator = RemoteMessageTransport.AtomicInteger()
         self.responseMap = {}
 
-    def send_request_message(self, request):
+    def send_request_message(self, request, source_object_id):
         logging.debug("[(B1) send request ]: " + str(request.packed_object()))
-        queue = self.addRequet(request)
+        queue = self.addRequet(request, source_object_id)
         response = queue.get()
         if response is None:
             raise IOError("fail subscribe" + request.object_id)
         return response
 
-    def addRequet(self, request):
+    def addRequet(self, request, source_object_id):
         try:
             sno = self.seqnoGenerator.increase()
             queue = RemoteMessageTransport.SynchronousQueue()
@@ -81,7 +81,10 @@ class RemoteMessageTransport(BaseMessageTransport):
             reqb.extend(pk.pack(
                 message_dispatcher.MessageDispatcher.TYPE_REQUEST))
             reqb.extend(pk.pack(sno))
-            reqb.extend(pk.pack(self.dispatcher.get_source_dispatcher_id()))
+            if self.dispatcher.monitor_enabled():  # Monitor
+                reqb.extend(pk.pack(source_object_id))
+            else:
+                reqb.extend(pk.pack(self.dispatcher.get_source_dispatcher_id()))
             reqb.extend(pk.pack(request.packed_object()))
             self.dispatcher.pushPublishQueue(
                 self,


### PR DESCRIPTION
Currently, the message sequence monitor tool does not work with the python-based ODENOS implementation.

This pull request provides monitoring support for the python-based one.
