### PR TITLE
Uncomment rest.root in etc/odenos.conf

### DIFF
--- a/etc/odenos.conf
+++ b/etc/odenos.conf
@@ -26,9 +26,9 @@ PROCESS	    romgr1,java,apps/java/sample_components/target/classes
 #PROCESS    romgr2,python,apps/python/sample_components
 
 # config rest port (default:10080)
-#rest.port  10080
+rest.port  10080
 # rest application root Directory.
-#rest.root  .
+rest.root  ./web
 
 # Pubsub server (e.g., Redis) addresses.
 # Set host name in the form of either IP address or host name.


### PR DESCRIPTION
This modification is not mandatory, but uncommenting these options causes no harm.
