### PR TITLE
Setting REST_ROOT to "./web" in the "odenos" shell script.

### DIFF
--- a/etc/odenos.conf
+++ b/etc/odenos.conf
@@ -26,9 +26,9 @@ PROCESS	    romgr1,java,apps/java/sample_components/target/classes
 #PROCESS    romgr2,python,apps/python/sample_components
 
 # config rest port (default:10080)
-#rest.port  10080
+rest.port  10080
 # rest application root Directory.
-#rest.root  .
+rest.root  ./web
 
 # Pubsub server (e.g., Redis) addresses.
 # Set host name in the form of either IP address or host name.

--- a/etc/odenos.conf
+++ b/etc/odenos.conf
@@ -26,9 +26,9 @@ PROCESS	    romgr1,java,apps/java/sample_components/target/classes
 #PROCESS    romgr2,python,apps/python/sample_components
 
 # config rest port (default:10080)
-rest.port  10080
+#rest.port  10080
 # rest application root Directory.
-rest.root  ./web
+#rest.root  ./web
 
 # Pubsub server (e.g., Redis) addresses.
 # Set host name in the form of either IP address or host name.

--- a/odenos
+++ b/odenos
@@ -35,7 +35,7 @@ ODENOS_LIB=$ODENOS_ROOT/lib
 ODENOS_LOG=var/log
 ODENOS_TMP=/tmp
 REST_PORT=10080
-REST_ROOT=.
+REST_ROOT=./web
 
 ODENOS_OPT="-Xms512m -Xmx512m -server"
 ODENOS_MAIN=org.o3project.odenos.core.Odenos


### PR DESCRIPTION
This modification is not mandatory, but setting REST_ROOT to "./web" causes no harm.
