### PR TITLE
Introduce MessagePack instance pool to MessageBodyUnpacker

### DIFF
--- a/src/test/java/org/o3project/odenos/remoteobject/message/MessageBodyUnpackerTest.java
+++ b/src/test/java/org/o3project/odenos/remoteobject/message/MessageBodyUnpackerTest.java
@@ -20,16 +20,11 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -38,8 +33,8 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.mockito.internal.stubbing.answers.ThrowsExceptionClass;
 import org.msgpack.MessagePack;
 import org.msgpack.packer.Packer;
 import org.msgpack.type.ArrayValue;
@@ -51,26 +46,25 @@ import org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.ParseBodyEx
 import org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.StringList;
 import org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.StringMap;
 import org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.TemplateHashMap;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
- * 
+ *
  *
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ MessageBodyUnpacker.class })
 public class MessageBodyUnpackerTest {
 
   private MessageBodyUnpacker target;
+
+  private MessagePack mockmsgpack;
 
   /**
    * @throws java.lang.Exception
@@ -91,20 +85,14 @@ public class MessageBodyUnpackerTest {
    */
   @Before
   public void setUp() throws Exception {
-    target = Mockito.spy(new MessageBodyUnpacker() {
+    target = new TestMessageBodyUnpacker();
 
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
+    mockmsgpack = Mockito.mock(MessagePack.class);
+    ConcurrentLinkedQueue<MessagePack> pool
+        = Whitebox.getInternalState(MessageBodyUnpacker.class, "pool");
+    pool.clear();
+    pool.add(mockmsgpack);
 
-      }
-
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
   }
 
   /**
@@ -115,324 +103,200 @@ public class MessageBodyUnpackerTest {
     target = null;
   }
 
+  // FIXME this case is not really testing anything.
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBody(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBody(java.lang.Class)}.
    * @throws ParseBodyException
    */
   @Test
   public final void testInitializeWithNull() throws ParseBodyException {
-    target = PowerMockito.mock(MessageBodyUnpacker.class);
-
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
+    target = new TestMessageBodyUnpacker();
 
     assertThat(target.body, is(nullValue()));
     assertThat(target.bodyValue, is(nullValue()));
-    assertThat(Whitebox.getInternalState(target, "msgpack"),
-        is(notNullValue()));
 
   }
 
+  // FIXME this case is not really testing anything.
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBody(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBody(java.lang.Class)}.
    * @throws ParseBodyException
    */
   @Test
   public final void testInitializeWithBodyValue() throws ParseBodyException {
-    target = PowerMockito.mock(MessageBodyUnpacker.class);
+    target = new TestMessageBodyUnpacker();
 
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
     target.bodyValue = Mockito.mock(Value.class);
 
     assertThat(target.body, is(nullValue()));
     assertThat(target.bodyValue, is(notNullValue()));
-    assertThat(Whitebox.getInternalState(target, "msgpack"),
-        is(notNullValue()));
 
   }
 
+  // FIXME this case is not really testing anything.
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBody(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBody(java.lang.Class)}.
    * @throws ParseBodyException
    */
   @Test
   public final void testInitializeWithNotNull() throws ParseBodyException {
-    target = PowerMockito.mock(MessageBodyUnpacker.class);
+    target = new TestMessageBodyUnpacker();
 
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
     target.body = Mockito.mock(Object.class);
 
     assertThat(target.body, is(notNullValue()));
-    assertThat(Whitebox.getInternalState(target, "msgpack"),
-        is(notNullValue()));
-
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBody(java.lang.Class)}.
-   * @throws ParseBodyException
+   * Test method for {@link MessageBodyUnpacker#getBody(java.lang.Class)}.
    */
   @Test
-  public final void testGetBodyWithBodyNotNull() throws ParseBodyException {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
+  public final void testGetBodyWithBodyNotNull() throws IOException {
+    target = new TestMessageBodyUnpacker();
 
-      }
+    final String string = "Already unpacked";
+    target.body = string;
 
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
-    target.body = Mockito.mock(Object.class);
-
-    assertThat(target.getBody(String.class), is(notNullValue()));
-
+    assertThat(target.getBody(String.class), is(string));
+    verify(mockmsgpack, never()).unconvert(target.bodyValue);
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBody(java.lang.Class)}.
-   * @throws ParseBodyException
+   * Test method for {@link MessageBodyUnpacker#getBody(java.lang.Class)}.
    */
   @Test
-  public final void testGetBodyReturnNull() throws ParseBodyException {
-    target = PowerMockito.mock(MessageBodyUnpacker.class);
+  public final void testGetBodyReturnNull() throws IOException {
 
     assertThat(target.getBody(String.class), is(nullValue()));
-
+    verify(mockmsgpack, never()).unconvert(target.bodyValue);
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBody(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBody(java.lang.Class)}.
    * @throws IOException
    */
   @Test
   public final void testGetBodyWithBodyValueNotNull() throws IOException {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
 
-      }
-
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
-
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
     target.bodyValue = Mockito.mock(Value.class);
-    String ret = new String();
+    final String ret = "Unpacked value";
     when(mockmsgpack.convert(target.bodyValue, String.class)).thenReturn(
         ret);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
 
-    assertThat(target.getBody(String.class), is(notNullValue()));
-
+    assertThat(target.getBody(String.class), is(ret));
+    verify(mockmsgpack, never()).unconvert(target.bodyValue);
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBody(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBody(java.lang.Class)}.
    * @throws IOException
    */
   @Test
   public final void testGetBodyWithIoException() throws IOException {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
-
-      }
-
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
 
     target.bodyValue = Mockito.mock(Value.class);
 
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-
     when(mockmsgpack.convert(target.bodyValue, String.class)).thenThrow(
         new IOException());
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
 
     assertThat(target.getBody(String.class), is(nullValue()));
 
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyValue()}.
+   * Test method for {@link MessageBodyUnpacker#getBodyValue()}.
    * @throws IOException
    */
   @Test
   public final void testGetBodyValueWithBodyValueNotNull() throws IOException {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
-      }
 
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-      }
-    });
-
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
     target.bodyValue = Mockito.mock(Value.class);
 
     Value ret = target.getBodyValue();
 
+
     assertThat(ret, is(notNullValue()));
     assertThat(ret, is(target.bodyValue));
 
+    verify(mockmsgpack, never()).unconvert(target.bodyValue);
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyValue()}.
+   * Test method for {@link MessageBodyUnpacker#getBodyValue()}.
    * @throws IOException
    */
   @Test
   public final void testGetBodyValueReturnNull() throws IOException {
-    target = PowerMockito.mock(MessageBodyUnpacker.class);
 
     assertThat(target.getBodyValue(), is(nullValue()));
 
+    verify(mockmsgpack, never()).unconvert(target.bodyValue);
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyValue()}.
+   * Test method for {@link MessageBodyUnpacker#getBodyValue()}.
    * @throws IOException
    */
   @Test
   public final void testGetBodyValueWithBodyNotNull() throws IOException {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
-      }
 
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-      }
-    });
-
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
     target.body = Mockito.mock(Object.class);
     Value mockvalue = Mockito.mock(Value.class);
     when(mockmsgpack.unconvert(target.body)).thenReturn(mockvalue);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
 
     Value ret = target.getBodyValue();
 
     assertThat(ret, is(notNullValue()));
     assertThat(ret, is(mockvalue));
-
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyValue()}.
+   * Test method for {@link MessageBodyUnpacker#getBodyValue()}.
    * @throws IOException
    */
   @Test
   public final void testGetBodyValueWithIoException() throws IOException {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
-
-      }
-
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
 
     target.body = Mockito.mock(Object.class);
 
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-
     when(mockmsgpack.unconvert(target.body)).thenThrow(new IOException());
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
 
     assertThat(target.getBodyValue(), is(nullValue()));
 
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsMap(java.lang.Class)}.
-   *
+   * Test method for {@link MessageBodyUnpacker#getBodyAsMap(java.lang.Class)}.
    */
   @Test
-  public final void testGetBodyAsMapWithBodyNotNull()
-      throws ParseBodyException {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
+  public final void testGetBodyAsMapWithBodyNotNull() throws IOException {
 
-      }
+    Map<String, String> map = new HashMap<>();
+    target.body = map;
 
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
-    target.body = Mockito.mock(HashMap.class);
-
-    assertThat(target.getBodyAsMap(String.class), is(notNullValue()));
-
+    assertThat(target.getBodyAsMap(String.class), is(map));
+    verify(mockmsgpack, never()).unconvert(any());
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsMap(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBodyAsMap(java.lang.Class)}.
    */
   @Test
-  public final void testGetBodyAsMapReturnNull() {
-    target = PowerMockito.mock(MessageBodyUnpacker.class);
+  public final void testGetBodyAsMapReturnNull() throws IOException {
 
-    assertThat(target.getBodyAsMap(String.class).size(), is(0));
+    assertThat(target.getBodyAsMap(String.class), is(nullValue()));
+    verify(mockmsgpack, never()).unconvert(any());
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsMap(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBodyAsMap(java.lang.Class)}.
    */
   @Test
-  public final void testGetBodyAsMapWithBodyValueNotNull() {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
+  public final void testGetBodyAsMapWithBodyValueNotNull() throws IOException {
 
-      }
-
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
+    final Map<String, String> expected = new HashMap<>();
+    expected.put("statusCode", "initialize");
+    expected.put("returnCode", "OK");
 
     Value[] valuemap = new Value[4];
     valuemap[0] = ValueFactory.createRawValue("statusCode");
@@ -440,37 +304,26 @@ public class MessageBodyUnpackerTest {
     valuemap[2] = ValueFactory.createRawValue("returnCode");
     valuemap[3] = ValueFactory.createRawValue("OK");
 
+
     target.bodyValue = Mockito.mock(Value.class);
     MapValue map = Mockito.mock(MapValue.class);
     map = ValueFactory.createMapValue(valuemap);
     doReturn(map).when(target.bodyValue).asMapValue();
 
-    assertThat(target.getBodyAsMap(String.class), is(notNullValue()));
+    doReturn("initialize").when(mockmsgpack).convert(valuemap[1], String.class);
+    doReturn("OK").when(mockmsgpack).convert(valuemap[3], String.class);
+
+    assertThat(target.getBodyAsMap(String.class), is(expected));
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsMap(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBodyAsMap(java.lang.Class)}.
    * @throws IOException
    */
   @Test
   public final void testGetBodyAsMapWithIoException() throws IOException {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
-
-      }
-
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
     doThrow(new IOException()).when(mockmsgpack).convert(
         (Value) anyObject(), eq(String.class));
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
 
     Value[] valuemap = new Value[4];
     valuemap[0] = ValueFactory.createRawValue("statusCode");
@@ -488,60 +341,38 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsList(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBodyAsList(java.lang.Class)}.
    */
   @Test
-  public final void testGetBodyAsListWithBodyNotNull() {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
+  public final void testGetBodyAsListWithBodyNotNull() throws IOException {
 
-      }
+    List<String> list = new ArrayList<>();
+    target.body = list;
 
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
+    assertThat(target.getBodyAsList(String.class), is(sameInstance(list)));
 
-      }
-    });
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
-    target.body = Mockito.mock(ArrayList.class);
-
-    assertThat(target.getBodyAsList(String.class), is(notNullValue()));
+    verify(mockmsgpack, never()).convert(target.bodyValue, String.class);
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsList(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBodyAsList(java.lang.Class)}.
    */
   @Test
-  public final void testGetBodyAsListReturnNull() {
-    target = PowerMockito.mock(MessageBodyUnpacker.class);
+  public final void testGetBodyAsListReturnNull() throws IOException {
 
-    assertThat(target.getBodyAsList(String.class).size(), is(0));
+    assertThat(target.getBodyAsList(String.class), is(nullValue()));
+    verify(mockmsgpack, never()).convert(target.bodyValue, String.class);
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsList(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBodyAsList(java.lang.Class)}.
    */
   @Test
-  public final void testGetBodyAsListWithBodyValueNotNullTest() {
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
+  public final void testGetBodyAsListWithBodyValueNotNullTest() throws IOException {
 
-      }
-
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
+    List<String> expected = new ArrayList<>();
+    expected.add("body01");
+    expected.add("body02");
 
     Value[] valuearray = new Value[2];
     valuearray[0] = ValueFactory.createRawValue("body01");
@@ -552,33 +383,21 @@ public class MessageBodyUnpackerTest {
     array = ValueFactory.createArrayValue(valuearray);
     doReturn(array).when(target.bodyValue).asArrayValue();
 
-    assertThat(target.getBodyAsList(String.class), is(notNullValue()));
+    doReturn("body01").when(mockmsgpack).convert(valuearray[0], String.class);
+    doReturn("body02").when(mockmsgpack).convert(valuearray[1], String.class);
+
+    assertThat(target.getBodyAsList(String.class), is(expected));
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsList(java.lang.Class)}.
+   * Test method for {@link MessageBodyUnpacker#getBodyAsList(java.lang.Class)}.
    * @throws IOException
    */
   @Test
   public final void testGetBodyAsListWithIoExceptionTest() throws IOException {
 
-    target = PowerMockito.spy(new MessageBodyUnpacker() {
-      @Override
-      public void readFrom(Unpacker unpacker) throws IOException {
-        return;
-
-      }
-
-      @Override
-      public void writeTo(Packer packer) throws IOException {
-        return;
-
-      }
-    });
-    MessagePack mockmsgpack = Mockito.mock(MessagePack.class);
     doThrow(new IOException()).when(mockmsgpack).convert(
         (Value) anyObject(), eq(String.class));
-    Whitebox.setInternalState(target, "msgpack", mockmsgpack);
 
     Value[] valuearray = new Value[2];
     valuearray[0] = ValueFactory.createRawValue("body01");
@@ -594,32 +413,34 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsStringList()}.
+   * Test method for {@link MessageBodyUnpacker#getBodyAsStringList()}.
    * @throws ParseBodyException
    */
   @Test
   public final void testGetBodyAsStringList() throws ParseBodyException {
-    StringList ret = Mockito.mock(StringList.class);
-    when(target.getBody(StringList.class)).thenReturn(ret);
+    StringList ret = new StringList();
+    MessageBodyUnpacker mock = Mockito.mock(MessageBodyUnpacker.class, Mockito.CALLS_REAL_METHODS);
+    when(mock.getBody(StringList.class)).thenReturn(ret);
 
-    assertThat((StringList) target.getBodyAsStringList(), is(ret));
+    assertThat((StringList) mock.getBodyAsStringList(), is(sameInstance(ret)));
 
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#getBodyAsStringMap()}.
+   * Test method for {@link MessageBodyUnpacker#getBodyAsStringMap()}.
    * @throws ParseBodyException
    */
   @Test
   public final void testGetBodyAsStringMap() throws ParseBodyException {
-    StringMap ret = Mockito.mock(StringMap.class);
-    when(target.getBody(StringMap.class)).thenReturn(ret);
+    StringMap ret = new StringMap();
+    MessageBodyUnpacker mock = Mockito.mock(MessageBodyUnpacker.class, Mockito.CALLS_REAL_METHODS);
+    when(mock.getBody(StringMap.class)).thenReturn(ret);
 
-    assertThat((StringMap) target.getBodyAsStringMap(), is(ret));
+    assertThat((StringMap) mock.getBodyAsStringMap(), is(sameInstance(ret)));
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#isBodyNull()}.
+   * Test method for {@link MessageBodyUnpacker#isBodyNull()}.
    */
   @Test
   public final void testIsBodyNullTrueWithBodyNull() {
@@ -628,10 +449,10 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#isBodyNull()}.
+   * Test method for {@link MessageBodyUnpacker#isBodyNull()}.
    */
   @Test
-  public final void testIsBodyNullFalseWithBodyNull() {
+  public final void testIsBodyNullFalseWithBodyNotNull() {
     target.body = Mockito.mock(Object.class);
 
     assertThat(target.isBodyNull(), is(false));
@@ -639,7 +460,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#isBodyNull()}.
+   * Test method for {@link MessageBodyUnpacker#isBodyNull()}.
    */
   @Test
   public final void testIsBodyNullTrue() {
@@ -651,7 +472,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#isBodyNull()}.
+   * Test method for {@link MessageBodyUnpacker#isBodyNull()}.
    */
   @Test
   public final void testIsBodyNullFalse() {
@@ -663,7 +484,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#readFrom(org.msgpack.unpacker.Unpacker)}.
+   * Test method for {@link MessageBodyUnpacker#readFrom(org.msgpack.unpacker.Unpacker)}.
    * @throws IOException
    */
   @Test
@@ -678,20 +499,26 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#readFrom(org.msgpack.unpacker.Unpacker)}.
+   * Test method for {@link MessageBodyUnpacker#readFrom(org.msgpack.unpacker.Unpacker)}.
    * @throws IOException      */
   @Test(expected = IOException.class)
   public final void testReadFromWithIoException() throws IOException {
-    Unpacker unpacker = Mockito.mock(Unpacker.class);
+    Unpacker unpacker = Mockito.mock(Unpacker.class, new ThrowsExceptionClass(IOException.class));
 
-    doThrow(new IOException()).when(target).readFrom(unpacker);
+    target = new TestMessageBodyUnpacker() {
+        @Override
+        public void readFrom(Unpacker unpacker) throws IOException {
+            // call mocked unpacker to throw IOException;
+            unpacker.skip();
+        };
+    };
 
     target.readFrom(unpacker);
 
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#writeTo(org.msgpack.packer.Packer)}.
+   * Test method for {@link MessageBodyUnpacker#writeTo(org.msgpack.packer.Packer)}.
    */
   @Test
   public final void testWriteTo() {
@@ -704,21 +531,27 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker#writeTo(org.msgpack.packer.Packer)}.
+   * Test method for {@link MessageBodyUnpacker#writeTo(org.msgpack.packer.Packer)}.
    * @throws IOException
    */
   @Test(expected = IOException.class)
   public final void testWriteToWithIoException() throws IOException {
-    Packer packer = Mockito.mock(Packer.class);
+    Packer packer = Mockito.mock(Packer.class, new ThrowsExceptionClass(IOException.class));
 
-    doThrow(new IOException()).when(target).writeTo(packer);
+    target = new TestMessageBodyUnpacker() {
+        @Override
+        public void writeTo(Packer packer) throws IOException {
+            // call mocked packer to throw IOException;
+            packer.writeNil();
+        }
+    };
 
     target.writeTo(packer);
 
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.StringList#writeTo(org.msgpack.packer.Packer)}.
+   * Test method for {@link MessageBodyUnpacker.StringList#writeTo(org.msgpack.packer.Packer)}.
    * @throws IOException
    */
   @Test
@@ -735,7 +568,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.StringList#readFrom(org.msgpack.unpacker.Unpacker)}.
+   * Test method for {@link MessageBodyUnpacker.StringList#readFrom(org.msgpack.unpacker.Unpacker)}.
    * @throws IOException
    */
   @SuppressWarnings("unchecked")
@@ -756,7 +589,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.StringMap#writeTo(org.msgpack.packer.Packer)}.
+   * Test method for {@link MessageBodyUnpacker.StringMap#writeTo(org.msgpack.packer.Packer)}.
    * @throws IOException
    */
   @Test
@@ -772,7 +605,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.StringMap#readFrom(org.msgpack.unpacker.Unpacker)}.
+   * Test method for {@link MessageBodyUnpacker.StringMap#readFrom(org.msgpack.unpacker.Unpacker)}.
    * @throws IOException
    */
   @SuppressWarnings("unchecked")
@@ -793,7 +626,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.TemplateHashMap#TemplateHashMap(java.lang.Class<T>)}.
+   * Test method for {@link MessageBodyUnpacker.TemplateHashMap#TemplateHashMap(java.lang.Class<T>)}.
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Test
@@ -806,7 +639,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.TemplateHashMap#writeTo(org.msgpack.packer.Packer)}.
+   * Test method for {@link MessageBodyUnpacker.TemplateHashMap#writeTo(org.msgpack.packer.Packer)}.
    * @throws IOException
    */
   @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -828,7 +661,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.TemplateHashMap#readFrom(org.msgpack.unpacker.Unpacker)}.
+   * Test method for {@link MessageBodyUnpacker.TemplateHashMap#readFrom(org.msgpack.unpacker.Unpacker)}.
    * @throws IOException
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -852,7 +685,7 @@ public class MessageBodyUnpackerTest {
   public ExpectedException expectedException = ExpectedException.none();
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.ParseBodyException#ParseBodyException(java.lang.Throwable)}.
+   * Test method for {@link MessageBodyUnpacker.ParseBodyException#ParseBodyException(java.lang.Throwable)}.
    *
    */
   @Test
@@ -864,7 +697,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.ParseBodyException#ParseBodyException(java.lang.Throwable)}.
+   * Test method for {@link MessageBodyUnpacker.ParseBodyException#ParseBodyException(java.lang.Throwable)}.
    *
    */
   @Test
@@ -875,7 +708,7 @@ public class MessageBodyUnpackerTest {
   }
 
   /**
-   * Test method for {@link org.o3project.odenos.remoteobject.message.MessageBodyUnpacker.ParseBodyException#ParseBodyException(java.lang.Throwable)}.
+   * Test method for {@link MessageBodyUnpacker.ParseBodyException#ParseBodyException(java.lang.Throwable)}.
    *
    */
   @Test
@@ -885,6 +718,14 @@ public class MessageBodyUnpackerTest {
     expectedException.expectMessage("errorMessage");
     throw new ParseBodyException("errorMessage", new IOException());
 
+  }
+
+  private static class TestMessageBodyUnpacker extends MessageBodyUnpacker {
+    @Override
+    public void readFrom(Unpacker unpacker) throws IOException {}
+
+    @Override
+    public void writeTo(Packer packer) throws IOException {}
   }
 
 }

--- a/src/test/java/org/o3project/odenos/remoteobject/message/MessageBodyUnpackerTest.java
+++ b/src/test/java/org/o3project/odenos/remoteobject/message/MessageBodyUnpackerTest.java
@@ -92,7 +92,6 @@ public class MessageBodyUnpackerTest {
         = Whitebox.getInternalState(MessageBodyUnpacker.class, "pool");
     pool.clear();
     pool.add(mockmsgpack);
-
   }
 
   /**
@@ -101,6 +100,9 @@ public class MessageBodyUnpackerTest {
   @After
   public void tearDown() throws Exception {
     target = null;
+    ConcurrentLinkedQueue<MessagePack> pool
+        = Whitebox.getInternalState(MessageBodyUnpacker.class, "pool");
+    pool.clear();
   }
 
   // FIXME this case is not really testing anything.


### PR DESCRIPTION
MessageBodyUnpacker is super class of topology elements classes, etc. and MessagePack and it's related instances was using significant amount of memory when the topology size is large.

This patch will add a MessagePack instance pool, which will relax the issue described above.
