### PR TITLE
Change status code constants to primitive type

### DIFF
--- a/src/main/java/org/o3project/odenos/remoteobject/message/Response.java
+++ b/src/main/java/org/o3project/odenos/remoteobject/message/Response.java
@@ -28,16 +28,16 @@ import java.io.IOException;
  */
 public class Response extends MessageBodyUnpacker {
 
-  public static final Integer OK = 200;
-  public static final Integer CREATED = 201;
-  public static final Integer ACCEPTED = 202;
-  public static final Integer NO_CONTENT = 204;
-  public static final Integer BAD_REQUEST = 400;
-  public static final Integer FORBIDDEN = 403;
-  public static final Integer NOT_FOUND = 404;
-  public static final Integer METHOD_NOT_ALLOWED = 405;
-  public static final Integer CONFLICT = 409;
-  public static final Integer INTERNAL_SERVER_ERROR = 500;
+  public static final int OK = 200;
+  public static final int CREATED = 201;
+  public static final int ACCEPTED = 202;
+  public static final int NO_CONTENT = 204;
+  public static final int BAD_REQUEST = 400;
+  public static final int FORBIDDEN = 403;
+  public static final int NOT_FOUND = 404;
+  public static final int METHOD_NOT_ALLOWED = 405;
+  public static final int CONFLICT = 409;
+  public static final int INTERNAL_SERVER_ERROR = 500;
 
   private static final int MSG_NUM = 2;
 


### PR DESCRIPTION
Change status code constants to primitive type, so that it can be compared using ==, !=.

Existing code using Integer#equals should keep working with the help from auto boxing.
