### PR TITLE
Event, broadcast to subscribers, MUST be deep-copied to avoid thread contention.

### DIFF
--- a/src/main/java/org/o3project/odenos/remoteobject/messagingclient/MessageDispatcher.java
+++ b/src/main/java/org/o3project/odenos/remoteobject/messagingclient/MessageDispatcher.java
@@ -396,7 +396,7 @@ public class MessageDispatcher implements Closeable, IMessageListener {
                 }
               }
 
-              mail = new Mail(serial, sno, subscriber, channel, this, null, event);
+              mail = new Mail(serial, sno, subscriber, channel, this, null, deepCopy(event));
               mailbox = localObject.getMailbox();
               synchronized (mailbox) {
                 mailbox.add(mail);


### PR DESCRIPTION
This is a bug fix for #114.
