### PR TITLE
ZooKeeper client incorporated into odenos.py

### DIFF
--- a/odenos
+++ b/odenos
@@ -196,13 +196,15 @@ start_process() {
 		LOGGING_CONF=${ODENOS_CONF}/log_python.conf \
 		APP_LOG=${ODENOS_LOG}/odenos_${PROC_NAME}.log \
 		$PYTHON ${ODENOS_LIB}/python/org/o3project/odenos/core/odenos.py \
-		-r ${PROC_NAME} -d ${PROC_DIR} -S $MANAGER -i $HOST -p $PORT -m $MONITOR &
+		-r ${PROC_NAME} -d ${PROC_DIR} -S $MANAGER -i $HOST -p $PORT -m \
+	       	$MONITOR $ZOOKEEPER_HOST &
 
 	    echo $! > $ODENOS_TMP/odenos_${PROC_NAME}.pid
 
 	elif [ $PROC_TYPE = "ruby" ]; then
 	    # start ruby RemoteObjectManager
 	    echo $PROC_NAME, $PROC_TYPE, $PROC_DIR
+	    sleep 3
             $TREMA run -d "./src/main/ruby/org/o3project/odenos/core/odenos.rb --cmpmgr=$PROC_NAME"
 	fi
 	
@@ -244,7 +246,6 @@ start() {
 
     if [ -n "${MANAGER_ENABLED}" ]; then
         start_system
-        sleep 3
     fi
     start_process
 

--- a/src/main/java/org/o3project/odenos/core/Odenos.java
+++ b/src/main/java/org/o3project/odenos/core/Odenos.java
@@ -303,6 +303,7 @@ public final class Odenos {
 
     // ZooKeeper server start in embedded mode.
     if (parser.getZooKeeperEmbed()) {
+      ZooKeeperService.cleanUp();
       ZooKeeperService.startZkServer();
       log.debug("ZooKeeper server started in embedded mode");
       zooKeeperEmbedded = true;
@@ -370,7 +371,6 @@ public final class Odenos {
    * @param args arguments.
    * @throws Exception if failed to parse arguments, if failed to run.
    */
-  @SuppressWarnings("restriction")
   public static void main(String[] args) throws Exception {
     Odenos odenos = new Odenos();
 

--- a/src/main/java/org/o3project/odenos/core/util/ZooKeeperService.java
+++ b/src/main/java/org/o3project/odenos/core/util/ZooKeeperService.java
@@ -1,5 +1,6 @@
 package org.o3project.odenos.core.util;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.Properties;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.server.PurgeTxnLog;
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -58,6 +60,20 @@ public final class ZooKeeperService {
 
   public static void setZkDir(String dir) {
     zk_dir = dir;
+  }
+
+  /**
+   * Cleans up ZooKeeper transaction logs.
+   * 
+   * Note: this method is to be removed in the future, since ZooKeeper
+   * servers should run in other processes for stability.
+   */
+  public static void cleanUp() {
+    try {
+      PurgeTxnLog.purge(new File(zk_dir), new File(zk_dir), 3);
+    } catch (IOException e) {
+      log.error("Unable to clea up ZooKeeper transction logs");
+    }
   }
 
   /**

--- a/src/main/python/org/o3project/odenos/core/odenos.py
+++ b/src/main/python/org/o3project/odenos/core/odenos.py
@@ -17,10 +17,11 @@
 
 import imp
 import inspect
-import kazoo.client 
+#import kazoo.client 
 import logging
 import os
 from optparse import OptionParser
+import sys
 import time
 
 from org.o3project.odenos.core.component.dummy_driver import DummyDriver
@@ -31,6 +32,11 @@ from org.o3project.odenos.remoteobject.object_property import ObjectProperty
 from org.o3project.odenos.remoteobject.remote_object import RemoteObject
 from org.o3project.odenos.remoteobject.transport.message_dispatcher import MessageDispatcher
 
+try:
+    import kazoo.client
+except:
+    logging.error('*** Install kazoo! (pip install kazoo) ***')
+    sys.exit(1)
 
 class Parser(object):
 


### PR DESCRIPTION
## Enhancement abstract

odenos.py waits for system manager to be up. Right after the completion, odenos.py initiates component manager registration with the system manager.

odenos.py show the following error if "kazoo" python module is not found in the machine:

```
*** Install kazoo! (pip install kazoo) ***'
```

This commit also adds a new feature to clean up ./var/zookeeper directory when starting odenos. 
