### PR TITLE
A-1. Python Environment in doc/QUICKSTART.md

### DIFF
--- a/doc/QUICKSTART.md
+++ b/doc/QUICKSTART.md
@@ -79,8 +79,9 @@ Python or Ruby environment, please see "Appendix A".
 1. Install python packages
 
    ```
-   $ sudo apt-get install python-setuptools python-dev
+   $ sudo apt-get install python-setuptools python-dev python-pip
    $ sudo -E easy_install msgpack-python redis futures mock coverage
+   $ sudo pip install kazoo
    ```
 
 2. Add the following line to *./etc/odenos.conf*


### PR DESCRIPTION
I failed to load the python sample component. The console said ' ERROR:root:**\* Install kazoo! (pip install kazoo) ***' I installed kazoo using pip and checked that ODENOS successfully loaded the component.
### logs

``` bash
ubuntu@devel:~/odenos$ ./odenos start
--  ---------------------------------->
--   o-o  o-o   o--o o   o  o-o   o-o
--  o   o |  \  |    |\  | o   o |
--  |   | |   O O-o  | \ | |   |  o-o
--  o   o |  /  |    |  \| o   o     |
--   o-o  o-o   o--o o   o  o-o  o--o
--

starting ODENOS
romgr1, java, apps/java/sample_components/target/classes
romgr2, python, apps/python/sample_components
ubuntu@devel:~/odenos$ ERROR:root:*** Install kazoo! (pip install kazoo) ***
```
