### PR TITLE
result of walking through quick start

### DIFF
--- a/doc/QUICKSTART.md
+++ b/doc/QUICKSTART.md
@@ -79,8 +79,9 @@ Python or Ruby environment, please see "Appendix A".
 1. Install python packages
 
    ```
-   $ sudo apt-get install python-setuptools python-dev
+   $ sudo apt-get install python-setuptools python-dev python-pip
    $ sudo -E easy_install msgpack-python redis futures mock coverage
+   $ sudo pip install kazoo
    ```
 
 2. Add the following line to *./etc/odenos.conf*

--- a/doc/QUICKSTART.md
+++ b/doc/QUICKSTART.md
@@ -79,9 +79,8 @@ Python or Ruby environment, please see "Appendix A".
 1. Install python packages
 
    ```
-   $ sudo apt-get install python-setuptools python-dev python-pip
+   $ sudo apt-get install python-setuptools python-dev
    $ sudo -E easy_install msgpack-python redis futures mock coverage
-   $ sudo pip install kazoo
    ```
 
 2. Add the following line to *./etc/odenos.conf*

--- a/doc/QUICKSTART.md
+++ b/doc/QUICKSTART.md
@@ -80,7 +80,7 @@ Python or Ruby environment, please see "Appendix A".
 
    ```
    $ sudo apt-get install python-setuptools python-dev
-   $ sudo -E easy_install msgpack-python redis futures mock coverage
+   $ sudo -E easy_install msgpack-python redis futures mock coverage kazoo
    ```
 
 2. Add the following line to *./etc/odenos.conf*

--- a/src/test/ruby/org/o3project/odenos/component/driver/of_driver/test_openflow_controller.rb
+++ b/src/test/ruby/org/o3project/odenos/component/driver/of_driver/test_openflow_controller.rb
@@ -3178,7 +3178,11 @@ class TestOpenFlowController < MiniTest::Test
     match_obj = OFPFlowMatch.new(match_body)
     
     actions = []
+    actions << FlowActionOutput.new(output: "port01")
     actions << OFPFlowActionSetField.new(match: match_obj)
+
+    @base_controller.expects(:get_of_port_no).
+      with("node01", "port01").returns(0x001).once
 
     of_actions = @base_controller.send(
       :_edge_actions_to_trema_actions, "node01", actions)


### PR DESCRIPTION
1. to run python sample components, kazoo is required (Document)
2. ruby unit test failed. fixed action list and expects for the unit test.
