### PR TITLE
Fix for #142: Use java.lang.Runtime instead of sun.misc.SignalHandler

### DIFF
--- a/src/main/java/org/o3project/odenos/core/Odenos.java
+++ b/src/main/java/org/o3project/odenos/core/Odenos.java
@@ -375,21 +375,25 @@ public final class Odenos {
     Odenos odenos = new Odenos();
 
     // Graceful shutdown
-    Signal signal = new Signal("TERM");
-    Signal.handle(signal, new SignalHandler() {
-      public void handle(Signal signal) {
+    Thread hook = new Thread(new Runnable() {
+      @Override
+      public void run() {
         if (systemIsEnabled) {
+
+          // You add shutdown procedures here:
           // Shutdown method 1
           //       :
           // Shutdown method n
+          
+          // Shutdown ZooKeeper server
           if (zooKeeperEmbedded) {
             ZooKeeperService.stopZkServer();
           }
         }
         log.info("ODENOS is terminated.");
-        System.exit(0);
       }
     });
+    Runtime.getRuntime().addShutdownHook(hook);
 
     try {
       odenos.parseParameters(args);


### PR DESCRIPTION
This is a fix for #142.

The current code use sun.misc.SignalHandler for graceful shutdown, but java.lang.Runtime.addShutdownHook(Thread hook) is more standard way to capture SIGTERM emitted by kill command.

ODENOS had better use the latter method.
