### PR TITLE
error unittest for python

### DIFF
--- a/src/test/python/__init__.py
+++ b/src/test/python/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding:utf-8 -*-
+
+# Copyright 2015 NEC Corporation.                                          #
+#                                                                          #
+# Licensed under the Apache License, Version 2.0 (the "License");          #
+# you may not use this file except in compliance with the License.         #
+# You may obtain a copy of the License at                                  #
+#                                                                          #
+#   http://www.apache.org/licenses/LICENSE-2.0                             #
+#                                                                          #
+# Unless required by applicable law or agreed to in writing, software      #
+# distributed under the License is distributed on an "AS IS" BASIS,        #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #
+# See the License for the specific language governing permissions and      #
+# limitations under the License.                                           #
+


### PR DESCRIPTION
python unittest error fix.

========================== Python Unit Test ==========================
Coverage.py warning: No data was collected.
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/**main**.py", line 12, in <module>
    main(module=None)
  File "/usr/lib/python2.7/unittest/main.py", line 94, in **init**
    self.parseArgs(argv)
  File "/usr/lib/python2.7/unittest/main.py", line 113, in parseArgs
    self._do_discovery(argv[2:])
  File "/usr/lib/python2.7/unittest/main.py", line 214, in _do_discovery
    self.test = loader.discover(start_dir, pattern, top_level_dir)
  File "/usr/lib/python2.7/unittest/loader.py", line 204, in discover
    raise ImportError('Start directory is not importable: %r' % start_dir)
ImportError: Start directory is not importable: 'python.org'
## Name    Stmts   Miss  Cover
